### PR TITLE
fix(compat): handle paths in bats-core >=1.11

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -145,7 +145,7 @@ runs:
 
         # Archlinux style, except that we are not in a fakeroot env
         # https://gitlab.archlinux.org/archlinux/packaging/packages/bash-bats/-/blob/main/PKGBUILD
-        sed -i 's|BATS_ROOT/libexec/bats-core/bats|BATS_ROOT/share/bats/bats|g' bin/bats
+        sed -i 's|BATS_ROOT/libexec/bats-core/bats|BATS_ROOT/share/bats/bats|g' bin/bats lib/bats-core/*
         sed -i 's|BATS_BASE_LIBDIR=lib|BATS_BASE_LIBDIR=share|g' bin/bats
         sed -i 's|BATS_LIBDIR/bats-core/|BATS_LIBDIR/bats/|g' libexec/bats-core/*
         sed -i 's|BATS_LIBDIR/bats-core/|BATS_LIBDIR/bats/|g' lib/bats-core/*

--- a/action.yaml
+++ b/action.yaml
@@ -146,8 +146,9 @@ runs:
         # Archlinux style, except that we are not in a fakeroot env
         # https://gitlab.archlinux.org/archlinux/packaging/packages/bash-bats/-/blob/main/PKGBUILD
         sed -i 's|BATS_ROOT/libexec/bats-core/bats|BATS_ROOT/share/bats/bats|g' bin/bats
-        sed -i 's|BATS_ROOT/lib/bats-core/|BATS_ROOT/share/bats/|g' libexec/bats-core/*
-        sed -i 's|BATS_ROOT/lib/bats-core/|BATS_ROOT/share/bats/|g' lib/bats-core/*
+        sed -i 's|BATS_BASE_LIBDIR=lib|BATS_BASE_LIBDIR=share|g' bin/bats
+        sed -i 's|BATS_LIBDIR/bats-core/|BATS_LIBDIR/bats/|g' libexec/bats-core/*
+        sed -i 's|BATS_LIBDIR/bats-core/|BATS_LIBDIR/bats/|g' lib/bats-core/*
 
         for fn in libexec/bats-core/*; do
           install -Dm755 ${fn} \


### PR DESCRIPTION
v1.11.0 bats-core (released Mar 24, https://github.com/bats-core/bats-core/releases) paths break in bats-action.

It looks like the sed path rewrites do not catch all paths and we see errors like:
```
Bats v1.11.0 installed in /home/runner/.local/bin
...
/home/runner/.local/share/bats/bats: line 489: /home/runner/.local/lib/bats-core/validator.bash: No such file or directory
```
On the same repository, same version of the OS and github action runner that passed before when v1.10.0 was the latest:
```
Bats v1.10.0 installed in /home/runner/.local/bin
...
1..11
...
```